### PR TITLE
feat(doc): add `mkdocs-deploy.yml` for doc ci

### DIFF
--- a/.github/workflows/mkdocs-deploy.yml
+++ b/.github/workflows/mkdocs-deploy.yml
@@ -1,0 +1,25 @@
+name: ci
+on:
+  push:
+    branches:
+      - main
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
+      - uses: actions/cache@v3
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: .cache
+          restore-keys: |
+            mkdocs-material-
+      - run: pip install poetry
+      - run: poetry install --with docs
+      - run: poetry run mkdocs gh-deploy --force


### PR DESCRIPTION
feat(doc): initial version without `kroki`

This follows [`mkdocs-materials`](https://squidfunk.github.io/mkdocs-material/publishing-your-site/) but we may end up needing a full `docker` version to use `kroki` (see `local.yml` for details).